### PR TITLE
:bug: added parseInt to ensure c is an int

### DIFF
--- a/dialogs/simplebutton.js
+++ b/dialogs/simplebutton.js
@@ -22,7 +22,7 @@
 
 CKEDITOR.dialog.add('simplebuttonDialog', function (editor) {
 	var componentToHex = function (c) {
-		var hex = c.toString(16);
+		var hex = parseInt(c).toString(16);
 		return hex.length == 1 ? "0" + hex : hex;
 	};
 


### PR DESCRIPTION
While using the plugin I enconter an issue with the background color loading the RGB integers like '#1273525';
it looks like c was not an int.

this PR fixes the issue
